### PR TITLE
Remove unused Client::setResponseFactory()

### DIFF
--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -9,7 +9,6 @@ use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
@@ -97,13 +96,6 @@ final class Client implements ClientInterface, LoggerAwareInterface
     public function setRequestFactory(RequestFactoryInterface $requestFactory): void
     {
         $this->requestFactory = $requestFactory;
-    }
-
-    /**
-     * @deprecated the client does not create responses, so the response factory is not used; this method is kept for backwards compatibility only
-     */
-    public function setResponseFactory(ResponseFactoryInterface $responseFactory): void
-    {
     }
 
     private function getStreamFactory(): StreamFactoryInterface


### PR DESCRIPTION
Removes `Client::setResponseFactory()` entirely.

The client never creates responses (it only reads the HTTP client's response), so the response factory was never used — even before the 1.0.0 work the setter stored a value nothing ever read. Rather than keep it as a `@deprecated` no-op, it's removed outright as part of the **1.0.0 major release**.

⚠️ The Backwards Compatibility Check will report this as a break — that is expected and intended for the major version bump.