### PR TITLE
Allow facebook/php-business-sdk ^26.0 (Graph API v26.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=8.1",
         "ext-json": "*",
-        "facebook/php-business-sdk": "^25.0",
+        "facebook/php-business-sdk": "^25.0 || ^26.0",
         "php-http/discovery": "^1.20",
         "psr/http-client": "^1.0",
         "psr/http-client-implementation": "*",

--- a/tests/Client/ClientTest.php
+++ b/tests/Client/ClientTest.php
@@ -47,7 +47,7 @@ final class ClientTest extends TestCase
 
         $request = $httpClient->requests[0];
         self::assertSame('POST', $request->getMethod());
-        self::assertSame('https://graph.facebook.com/v25.0/pixel_id/events', (string) $request->getUri());
+        self::assertSame(sprintf('https://graph.facebook.com/v%s/pixel_id/events', ApiConfig::APIVersion), (string) $request->getUri());
         self::assertSame('data=%5B%7B%22event_name%22%3A%22Purchase%22%2C%22event_time%22%3A1658743659123%2C%22event_id%22%3A%22event_id%22%2C%22action_source%22%3A%22website%22%7D%5D', (string) $request->getBody());
     }
 


### PR DESCRIPTION
## Summary

Closes #10.

- `composer.json`: `facebook/php-business-sdk` widened from `^25.0` to `^25.0 || ^26.0`, so consumers can move to Graph API **v26.0** (26.0.1 requires PHP >= 8.0, `guzzlehttp/guzzle ^6.5 || ^7.0`, `facebook/capi-param-builder-php ^1.3.1`).
- No `src/` changes: the package is only used for `ApiConfig::APIVersion`, `Normalizer::normalize` and `Util::hash`, all present and unchanged in 26.x — the existing tests that pin the hashed/normalized payloads pass unchanged against 26.0.1.
- `ClientTest::it_sends_event` asserted a hardcoded `v25.0` endpoint, which would fail on `highest`; it now derives the version from `ApiConfig::APIVersion` (same approach as the new tests in #11).

## Test plan

- [x] `composer update facebook/php-business-sdk --with-all-dependencies` → 26.0.1; `ApiConfig::APIVersion` = `26.0`
- [x] `vendor/bin/phpunit`, `vendor/bin/phpstan analyse`, `vendor/bin/ecs check`, `vendor/bin/composer-dependency-analyser`, `composer normalize --dry-run` — all green on 26.0.1
- [x] `vendor/bin/phpunit` on PHP 8.1 against 26.0.1
- [x] Lowest (25.0.0) is unchanged and remains covered by the CI `lowest` matrix
- [x] `LiveClientTest` against 26.x — run 2026-08-31 after merge (SDK 26.0.1, PHP 8.4): Meta returned 200 for the `ViewContent` test event.

The aside in #10 (dropping the dependency in favour of an explicit API-version constant) is intentionally left for a separate discussion.
